### PR TITLE
Support "plugin" shared-library

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ etn_target(shared ${PROJECT_NAME}
         fty-utils
 )
 ```
-The shared library named "lib${PROJECT_NAME}.so" will be install in "${CMAKE_INSTALL_PREFIX}/lib/${PROJECT_NAME}lib${PROJECT_NAME}.so"  
+The shared library named "lib${PROJECT_NAME}.so" will be installed in "${CMAKE_INSTALL_PREFIX}/lib/${PROJECT_NAME}lib${PROJECT_NAME}.so"
 The public header named "myPublicClass.hpp" will be install in "${CMAKE_INSTALL_PREFIX}/lib/**fty**/myPublicClass.hpp"  
 All the cmake package information files will be installed in ${CMAKE_INSTALL_PREFIX}/shared/cmake/..    
+A pkgconfig file will be generated, if not user provided, and installed in "${CMAKE_INSTALL_PREFIX}/lib/${PROJECT_NAME}lib${PROJECT_NAME}.pc"
+
+Note that if neither PUBLIC_INCLUDE_DIR nor PUBLIC_HEADERS is used, it is assumed that this shared library is not public.
+Hence cmake packaging information and pkgconfig file will not be generated nor installed.

--- a/cmake/target/export.cmake
+++ b/cmake/target/export.cmake
@@ -3,45 +3,53 @@ include(CMakePackageConfigHelpers)
 ##############################################################################################################
 
 function(export_target target)
-    set(exportCmakeFile   ${target}-targets.cmake)
-    set(exportCmakeConfig ${target}-config.cmake)
-    set(exportVersionFile ${CMAKE_CURRENT_BINARY_DIR}/${target}-config-version.cmake)
+    # check if .cmake are actually needed (-dev pkg, exporting public includes and .so)
+    if ( args_PUBLIC_INCLUDE_DIR OR args_PUBLIC_HEADERS )
+        set(exportCmakeFile   ${target}-targets.cmake)
+        set(exportCmakeConfig ${target}-config.cmake)
+        set(exportVersionFile ${CMAKE_CURRENT_BINARY_DIR}/${target}-config-version.cmake)
 
-    export(TARGETS ${target} FILE ${exportCmakeFile})
+        export(TARGETS ${target} FILE ${exportCmakeFile})
 
-    if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${exportCmakeConfig}.in)
-        set(exportCmakeConfigIn ${CMAKE_CURRENT_BINARY_DIR}/${target}-config.cmake.in)
-        set(exportCmakeConfig ${CMAKE_CURRENT_BINARY_DIR}/${target}-config.cmake)
-        file(WRITE ${exportCmakeConfigIn} "@PACKAGE_INIT@\ninclude(\"\${CMAKE_CURRENT_LIST_DIR}/${exportCmakeFile}\")")
+        if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${exportCmakeConfig}.in)
+            set(exportCmakeConfigIn ${CMAKE_CURRENT_BINARY_DIR}/${target}-config.cmake.in)
+            set(exportCmakeConfig ${CMAKE_CURRENT_BINARY_DIR}/${target}-config.cmake)
+            file(WRITE ${exportCmakeConfigIn} "@PACKAGE_INIT@\ninclude(\"\${CMAKE_CURRENT_LIST_DIR}/${exportCmakeFile}\")")
+        else()
+            set(exportCmakeConfigIn ${CMAKE_CURRENT_SOURCE_DIR}/${exportCmakeConfig}.in)
+            set(exportCmakeConfig ${CMAKE_CURRENT_BINARY_DIR}/${target}-config.cmake)
+        endif()
+
+        set(CMAKE_INSTALL_DIR ${CMAKE_INSTALL_DATAROOTDIR}/cmake/${target})
+
+        configure_package_config_file(
+            ${exportCmakeConfigIn}
+            ${exportCmakeConfig}
+            INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${target}/cmake
+            PATH_VARS CMAKE_INSTALL_DIR CMAKE_INSTALL_BINDIR CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_INCLUDEDIR
+        )
+
+        write_basic_package_version_file(
+            ${exportVersionFile}
+            VERSION ${PACKAGE_VERSION}
+            COMPATIBILITY SameMajorVersion
+        )
+
+        if (EXISTS "${FTY_CMAKE_CMAKE_DIR}/templates/")
+            set(templates "${FTY_CMAKE_CMAKE_DIR}/templates")
+        else()
+            set(templates "${CMAKE_CURRENT_LIST_DIR}/cmake/templates")
+        endif()
+
+        etn_set_custom_property(${target} CMAKE_EXPORT_FILE  ${exportCmakeFile})
+        etn_set_custom_property(${target} CMAKE_CONFIG_FILE  ${exportCmakeConfig})
+        etn_set_custom_property(${target} CMAKE_VERSION_FILE ${exportVersionFile})
     else()
-        set(exportCmakeConfigIn ${CMAKE_CURRENT_SOURCE_DIR}/${exportCmakeConfig}.in)
-        set(exportCmakeConfig ${CMAKE_CURRENT_BINARY_DIR}/${target}-config.cmake)
+        message ( "-- Disabling CMake files support (not requested / needed)" )
+        etn_set_custom_property(${target} CMAKE_EXPORT_FILE  "")
+        etn_set_custom_property(${target} CMAKE_CONFIG_FILE  "")
+        etn_set_custom_property(${target} CMAKE_VERSION_FILE "")
     endif()
-
-    set(CMAKE_INSTALL_DIR ${CMAKE_INSTALL_DATAROOTDIR}/cmake/${target})
-
-    configure_package_config_file(
-        ${exportCmakeConfigIn}
-        ${exportCmakeConfig}
-        INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${target}/cmake
-        PATH_VARS CMAKE_INSTALL_DIR CMAKE_INSTALL_BINDIR CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_INCLUDEDIR
-    )
-
-    write_basic_package_version_file(
-        ${exportVersionFile}
-        VERSION ${PACKAGE_VERSION}
-        COMPATIBILITY SameMajorVersion
-    )
-
-    if (EXISTS "${FTY_CMAKE_CMAKE_DIR}/templates/")
-        set(templates "${FTY_CMAKE_CMAKE_DIR}/templates")
-    else()
-        set(templates "${CMAKE_CURRENT_LIST_DIR}/cmake/templates")
-    endif()
-
-    etn_set_custom_property(${target} CMAKE_EXPORT_FILE  ${exportCmakeFile})
-    etn_set_custom_property(${target} CMAKE_CONFIG_FILE  ${exportCmakeConfig})
-    etn_set_custom_property(${target} CMAKE_VERSION_FILE ${exportVersionFile})
 
     # Pkg config
     get_target_property(type ${target} TYPE)
@@ -76,25 +84,28 @@ function(export_target target)
         set(libdir     ${dir})
         set(includedir ${inc})
 
+        # Use existing pkgconfig file, if provided
         if (EXISTS ${src}/${target}.pc.in)
             configure_file(${src}/${target}.pc.in ${pgkname} @ONLY)
         else()
-            configure_file(${templates}/package.pc.in ${pgkname} @ONLY)
+            # Otherwise, check if it's actually needed (-dev pkg, exporting public includes and .so)
+            if ( args_PUBLIC_INCLUDE_DIR OR args_PUBLIC_HEADERS )
+                configure_file(${templates}/package.pc.in ${pgkname} @ONLY)
+            endif()
         endif()
 
         # Exported pkg file
-        set(pgkname    ${CMAKE_CURRENT_BINARY_DIR}/export/lib${target}.pc)
+        #set(pgkname    ${CMAKE_CURRENT_BINARY_DIR}/export/lib${target}.pc)
         set(prefix     ${CMAKE_INSTALL_PREFIX})
         set(libdir     ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
         set(includedir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})
 
-        if (EXISTS ${src}/${target}.pc.in)
-            configure_file(${src}/${target}.pc.in ${pgkname} @ONLY)
+        if ( args_PUBLIC_INCLUDE_DIR OR args_PUBLIC_HEADERS )
+            etn_set_custom_property(${target} CMAKE_PKG_FILE ${pgkname})
         else()
-            configure_file(${templates}/package.pc.in ${pgkname} @ONLY)
+            message ( "-- Disabling pkgconfig support (not requested / needed)" )
+            etn_set_custom_property(${target} CMAKE_PKG_FILE "")
         endif()
-
-        etn_set_custom_property(${target} CMAKE_PKG_FILE ${pgkname})
     endif()
 endfunction()
 

--- a/cmake/target/target.cmake
+++ b/cmake/target/target.cmake
@@ -93,7 +93,7 @@ macro(create_target name type output)
         etn_set_custom_property(${name} CONFIGS "${arg_CONFIGS}")
     endif()
 
-    # Add systemd servive files to install
+    # Add systemd service files to install
     if (arg_SYSTEMD)
         copy_files(${name} "${arg_SYSTEMD}")
         etn_set_custom_property(${name} SYSTEMD "${arg_SYSTEMD}")


### PR DESCRIPTION
if neither PUBLIC_INCLUDE_DIR nor PUBLIC_HEADERS is used, it
is assumed that this shared library is not public. Hence
don't generate / install cmake packaging information and
pkgconfig file

Signed-off-by: Arnaud Quette <ArnaudQuette@eaton.com>